### PR TITLE
Update instruction with the new recommended urls style.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ CONFIGURATION
 2. Add `taggit_bootstrap` into your `INSTALLED_APPS`.
 3. Add `taggit_bootstrap.urls` into your urls patterns. E.q.
 ```
-urlpatterns = patterns('',
-  ...  
-  url(r'^taggit/',include('taggit_bootstrap.urls')),
-)
+urlpatterns = [
+    ...  
+    url(r'^taggit/', include('taggit_bootstrap.urls')),
+]
 ```
 4. Use TagsInput widget like this
 ```

--- a/taggit_bootstrap/urls.py
+++ b/taggit_bootstrap/urls.py
@@ -1,5 +1,5 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from .views import *
-urlpatterns = patterns('', 
-		url(r'^$',TaggitBoostrapView.as_view(),name='taggit-bootstrap')
-	)
+urlpatterns = [
+    url(r'^$', TaggitBoostrapView.as_view(), name='taggit-bootstrap')
+]


### PR DESCRIPTION
Silence RemovedInDjango110Warning for urls.

Fix PEP8 space issue in comments.